### PR TITLE
fix: Update actions/upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './dist'
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
The GitHub Actions CI pipeline was failing with an error: "Error: Missing download info for actions/upload-artifact@v3"

This error appeared to be caused by an outdated internal dependency in `actions/upload-pages-artifact@v1`.

This commit updates `actions/upload-pages-artifact` from `v1` to `v3` in the `deploy.yml` workflow to resolve this issue by using a newer version of the action which should, in turn, use an updated and available version of its internal dependencies.