### PR TITLE
fix: Add actions:read permission to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read # This is the new line
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -42,7 +43,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './dist'
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
The deploy workflow was failing with the error:
"HttpError: Cannot find any run with github.run_id ..."

This error can occur when the workflow triggered by `workflow_run` does not have sufficient permissions to read information from the triggering workflow.

This commit adds `actions: read` to the `permissions` block in the `deploy.yml` workflow to grant the necessary access.