### PR TITLE
fix: Update actions/deploy-pages to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,4 +48,4 @@ jobs:
           path: './dist'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The deploy workflow continued to fail with the error: "HttpError: Cannot find any run with github.run_id ..." during the `actions/deploy-pages` step, even after verifying GitHub Pages settings and `actions:read` permissions.

This commit updates `actions/deploy-pages` from `v2` to `v4` in the `deploy.yml` workflow. Newer versions often include bug fixes and improvements that may resolve such interaction issues with the GitHub Pages deployment process.