### PR TITLE
Here's the updated commit message:

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,9 +31,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
       - name: Build project
         run: VITE_GIT_HASH=${GITHUB_SHA::6} bun run build
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Install dependencies


### PR DESCRIPTION
chore: Update GitHub Actions to latest major versions

This commit updates several GitHub Actions used in your CI/CD workflows to their latest stable major versions.

Updates include:
- `actions/checkout` from `v3` to `v4`
- `oven-sh/setup-bun` from `v1` to `v2`
- `actions/configure-pages` from `v3` to `v5`

These updates help ensure your workflows use the most current features, bug fixes, and security patches provided by these actions. `actions/upload-pages-artifact` and `actions/deploy-pages` were already at their latest major versions (`v3` and `v4` respectively) and remain unchanged.